### PR TITLE
Minor fixes to project.clj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-resources/
-docs/index.html
-target/
-.lein-*
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+/*-init.clj
+

--- a/project.clj
+++ b/project.clj
@@ -4,16 +4,24 @@
   :license {:name "BSD (2 Clause)"
             :url "http://opensource.org/licenses/BSD-2-Clause"}
   :source-paths ["src"]
-  :dependencies [[org.clojure/clojurescript "0.0-2498"]
-                 [org.clojure/clojure "1.6.0"]]
+
+  :dependencies [[org.clojure/clojurescript "0.0-2498" :scope "provided"]
+                 [org.clojure/clojure "1.6.0" :scope "provided"]]
+
   :scm {:name "git"
         :url "https://github.com/dialelo/hodgepodge"}
-  :hooks [leiningen.cljsbuild]
-  :plugins [[lein-cljsbuild "1.0.3"]]
+
+  :jar-exclusions [#"^test/.*"]
+  :clean-targets ^{:protect false} ["target"
+                                    "resources/test/out"
+                                    "resources/test/test.js"]
+
+  :profiles {:dev {:hooks [leiningen.cljsbuild]
+                   :plugins [[lein-cljsbuild "1.0.4"]]}}
   :cljsbuild {:builds {:test
                        {:source-paths ["src" "test"]
                         :compiler {
                             :output-to "resources/test/test.js"
-                            :output-dir "resources/test"
+                            :output-dir "resources/test/out"
                             :optimizations :advanced}}}
               :test-commands {"unit" ["phantomjs" "resources/test/runner.js"]}})


### PR DESCRIPTION
It maybe requires new release. 

The technical explication is found on the commit message. But the summary is that:

Having some development dependencies as runtime dependencies, causes that the sloth application compiles the cljs.core namespace files with old version of clojurescript.
I discover it using (volatile!) function, and I found that is not exists. Researching some hours I found that some files as result of compilartion of sloth, are compiled with clojurescript version that does not has volatile! function.

Researching more time, and testing with fresh installation I found that this strange behavior starts when I add hodgepodge as dependency. And the purposed changes fixes that behavior.